### PR TITLE
Storage Details menu

### DIFF
--- a/jolt_os/hal/storage/storage_ataes132a.c
+++ b/jolt_os/hal/storage/storage_ataes132a.c
@@ -25,9 +25,10 @@
 #include "aes132_cmd.h"
 #include "esp_log.h"
 
-static const char* TAG = "storage_ataes132a";
 
 #if CONFIG_JOLT_STORE_ATAES132A 
+
+static const char* TAG = "storage_ataes132a";
 
 bool storage_ataes132a_startup() {
     if( !(storage_internal_startup() && 0 == aes132_jolt_setup()) ) {

--- a/jolt_os/jolt_gui/jolt_gui.c
+++ b/jolt_os/jolt_gui/jolt_gui.c
@@ -367,7 +367,7 @@ void jolt_gui_sem_give() {
 
 /* Finds the first child object with the object identifier.
  * Returns NULL if child not found. */
-lv_obj_t *jolt_gui_find(lv_obj_t *parent, jolt_gui_obj_id_t id) {
+lv_obj_t *jolt_gui_find(const lv_obj_t *parent, jolt_gui_obj_id_t id) {
     lv_obj_t *child = NULL;
     if( NULL == parent ) {
         ESP_LOGW(TAG, "Cannot search a NULL pointer.");

--- a/jolt_os/jolt_gui/jolt_gui.h
+++ b/jolt_os/jolt_gui/jolt_gui.h
@@ -277,7 +277,7 @@ void jolt_gui_sem_give();
  * @param[in] parent Any LVGL object who's children we want to search
  * @param[in] id ID we are searching for.
  */
-lv_obj_t *jolt_gui_find(lv_obj_t *parent, jolt_gui_obj_id_t id);
+lv_obj_t *jolt_gui_find(const lv_obj_t *parent, jolt_gui_obj_id_t id);
 
 /**
  * @brief Convert the enumerated value to a constant string 

--- a/jolt_os/jolt_gui/jolt_gui.h
+++ b/jolt_os/jolt_gui/jolt_gui.h
@@ -80,7 +80,7 @@ typedef void (*jolt_gui_event_cb_t)(jolt_gui_obj_t *obj, jolt_gui_event_t event)
  *********************/
 
 /**
- * Get the parenting screen for some object.
+ * @brief Get the parenting screen for some object.
  * If object is NULL, return the currently active screen.
  *
  * @param obj object to get screen object of.
@@ -321,14 +321,6 @@ lv_obj_t *jolt_gui_obj_get_parent( const lv_obj_t *obj );
 /**********
  * Macros *
  **********/
-/**
- * @brief To be used in a JOLT_GUI_CTX; breaks if passed in value is NULL 
- */
-#define BREAK_IF_NULL( obj ) ({\
-        void *x = obj; \
-        if( NULL == x ) break; \
-        x; \
-        })
 
 /**
  * @brief Declares all the must have objects (parent, label_title, cont_body) in a Jolt Screen.

--- a/jolt_os/jolt_gui/jolt_gui.h
+++ b/jolt_os/jolt_gui/jolt_gui.h
@@ -306,7 +306,7 @@ lv_obj_t *jolt_gui_obj_get_parent( const lv_obj_t *obj );
 #define JOLT_GUI_CTX \
     MPP_BEFORE(1, jolt_gui_sem_take() ) \
     MPP_DO_WHILE(2, false) \
-    MPP_BREAK_HANDLER(3, ESP_LOGE(TAG, "%s: JOLT_GUI_CTX break L%d", __func__, __LINE__)) \
+    MPP_BREAK_HANDLER(3, ESP_LOGE(TAG, "%s: JOLT_GUI_CTX break", __func__)) \
     MPP_FINALLY(4, jolt_gui_sem_give() )
 
 #define if_not(x) if(!(x))

--- a/jolt_os/jolt_gui/jolt_gui_menu.c
+++ b/jolt_os/jolt_gui/jolt_gui_menu.c
@@ -1,4 +1,4 @@
-#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
+//#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
 
 #include "esp_log.h"
 #include "jolt_gui_menu.h"
@@ -81,7 +81,7 @@ jolt_gui_obj_t *jolt_gui_scr_menu_create(const char *title) {
 }
 
 /* Gets the list object of a menu screen */
-jolt_gui_obj_t *jolt_gui_scr_menu_get_list(jolt_gui_obj_t *parent) {
+jolt_gui_obj_t *jolt_gui_scr_menu_get_list(const jolt_gui_obj_t *parent) {
     jolt_gui_obj_t *menu = NULL;
     JOLT_GUI_CTX{
         jolt_gui_obj_t *cont_body = NULL;
@@ -183,7 +183,15 @@ void jolt_gui_scr_menu_set_btn_selected(jolt_gui_obj_t *par, jolt_gui_obj_t *btn
     }
 }
 
-void jolt_gui_scr_menu_remove(jolt_gui_obj_t *par, uint16_t start, uint16_t end) {
+void jolt_gui_scr_menu_remove(lv_obj_t *par, lv_obj_t *btn) {
+    JOLT_GUI_CTX{
+        jolt_gui_obj_t *list = BREAK_IF_NULL(jolt_gui_scr_menu_get_list(par));
+        int32_t index = lv_list_get_btn_index(list, btn);
+        lv_list_remove(list, index);
+    }
+}
+
+void jolt_gui_scr_menu_remove_indices(jolt_gui_obj_t *par, uint16_t start, uint16_t end) {
     if( 0 == end ) {
         end = UINT16_MAX;
     }
@@ -220,4 +228,13 @@ int32_t jolt_gui_scr_menu_get_btn_index( jolt_gui_obj_t *btn ) {
         index = lv_list_get_btn_index(NULL, btn);
     }
     return index;
+}
+
+uint16_t jolt_gui_scr_menu_len(const lv_obj_t *par) {
+    uint16_t len = 0;
+    JOLT_GUI_CTX{
+        jolt_gui_obj_t *list = BREAK_IF_NULL(jolt_gui_scr_menu_get_list(par));
+        len = lv_list_get_size(list);
+    }
+    return len;
 }

--- a/jolt_os/jolt_gui/jolt_gui_menu.c
+++ b/jolt_os/jolt_gui/jolt_gui_menu.c
@@ -145,25 +145,28 @@ jolt_gui_obj_t *jolt_gui_scr_menu_add_sw( jolt_gui_obj_t *btn ) {
 lv_obj_t *jolt_gui_scr_menu_add_info( jolt_gui_obj_t *btn, const char *info ) {
     jolt_gui_obj_t *info_label = NULL;
     JOLT_GUI_CTX{
+        jolt_gui_obj_t * info_label_tmp = NULL;
         jolt_gui_obj_t *btn_label = lv_list_get_btn_label( btn );
 
         /* Creating another child label under a list element interfere's with 
          * how lvgl handles signal callbacks, so we have to first create a container */
         jolt_gui_obj_t *cont = BREAK_IF_NULL(lv_cont_create(btn, NULL));
+        lv_cont_set_style(cont, LV_CONT_STYLE_MAIN, &lv_style_transp_tight);
         lv_cont_set_fit(cont, LV_FIT_TIGHT);
-        lv_cont_set_style(cont, LV_CONT_STYLE_MAIN, &lv_style_transp);
 
-        info_label = BREAK_IF_NULL(lv_label_create(cont, btn_label));
-
-        lv_label_set_long_mode(info_label, LV_LABEL_LONG_EXPAND);
-        lv_label_set_text(info_label, info);
-        lv_obj_align(cont, btn, LV_ALIGN_IN_RIGHT_MID, 0, 0);
+        info_label_tmp = BREAK_IF_NULL(lv_label_create(cont, btn_label));
+        lv_label_set_long_mode(info_label_tmp, LV_LABEL_LONG_EXPAND);
+        lv_label_set_text(info_label_tmp, info);
 
         {
-            lv_coord_t info_width = lv_obj_get_width( info_label );
+            lv_coord_t info_width = lv_obj_get_width( cont );
             lv_coord_t btn_width = lv_obj_get_width( btn_label );
             lv_obj_set_width( btn_label, btn_width - info_width );
+            lv_obj_align(btn_label, btn, LV_ALIGN_IN_LEFT_MID, 0, 0);
         }
+
+        lv_obj_align(cont, btn_label, LV_ALIGN_OUT_RIGHT_MID, 0, 0);
+        info_label = info_label_tmp;
     }
     return info_label;
 }

--- a/jolt_os/jolt_gui/jolt_gui_menu.c
+++ b/jolt_os/jolt_gui/jolt_gui_menu.c
@@ -142,6 +142,32 @@ jolt_gui_obj_t *jolt_gui_scr_menu_add_sw( jolt_gui_obj_t *btn ) {
     return sw;
 }
 
+lv_obj_t *jolt_gui_scr_menu_add_info( jolt_gui_obj_t *btn, const char *info ) {
+    jolt_gui_obj_t *info_label = NULL;
+    JOLT_GUI_CTX{
+        jolt_gui_obj_t *btn_label = lv_list_get_btn_label( btn );
+
+        /* Creating another child label under a list element interfere's with 
+         * how lvgl handles signal callbacks, so we have to first create a container */
+        jolt_gui_obj_t *cont = BREAK_IF_NULL(lv_cont_create(btn, NULL));
+        lv_cont_set_fit(cont, LV_FIT_TIGHT);
+        lv_cont_set_style(cont, LV_CONT_STYLE_MAIN, &lv_style_transp);
+
+        info_label = BREAK_IF_NULL(lv_label_create(cont, btn_label));
+
+        lv_label_set_long_mode(info_label, LV_LABEL_LONG_EXPAND);
+        lv_label_set_text(info_label, info);
+        lv_obj_align(cont, btn, LV_ALIGN_IN_RIGHT_MID, 0, 0);
+
+        {
+            lv_coord_t info_width = lv_obj_get_width( info_label );
+            lv_coord_t btn_width = lv_obj_get_width( btn_label );
+            lv_obj_set_width( btn_label, btn_width - info_width );
+        }
+    }
+    return info_label;
+}
+
 void jolt_gui_scr_menu_set_btn_selected(jolt_gui_obj_t *par, jolt_gui_obj_t *btn){
     JOLT_GUI_CTX{
         jolt_gui_obj_t *list = BREAK_IF_NULL(jolt_gui_scr_menu_get_list(par));

--- a/jolt_os/jolt_gui/jolt_gui_menu.c
+++ b/jolt_os/jolt_gui/jolt_gui_menu.c
@@ -19,9 +19,12 @@ static lv_signal_cb_t old_list_signal = NULL;     /*Store the old signal functio
 
 static void set_selected_label_long_mode(jolt_gui_obj_t *list, lv_label_long_mode_t mode){
     JOLT_GUI_CTX{
-        jolt_gui_obj_t *btn = BREAK_IF_NULL(lv_list_get_btn_selected(list));
-        jolt_gui_obj_t *label = BREAK_IF_NULL(lv_list_get_btn_label(btn));
-        lv_label_set_long_mode(label, mode);
+        uint16_t len = lv_list_get_size(list);
+        if( len > 0 ) {
+            jolt_gui_obj_t *btn = BREAK_IF_NULL(lv_list_get_btn_selected(list));
+            jolt_gui_obj_t *label = BREAK_IF_NULL(lv_list_get_btn_label(btn));
+            lv_label_set_long_mode(label, mode);
+        }
     }
 }
 

--- a/jolt_os/jolt_gui/jolt_gui_menu.h
+++ b/jolt_os/jolt_gui/jolt_gui_menu.h
@@ -42,7 +42,7 @@ lv_obj_t *jolt_gui_scr_menu_add(lv_obj_t *par, const void *img_src,
  * @param[in] par menu screen
  * @return lv_list object
  */
-lv_obj_t *jolt_gui_scr_menu_get_list(lv_obj_t *par);
+lv_obj_t *jolt_gui_scr_menu_get_list(const lv_obj_t *par);
 
 /**
  * @brief Gets the screen object given a selected button of a menu.
@@ -76,12 +76,19 @@ lv_obj_t *jolt_gui_scr_menu_add_info( lv_obj_t *btn, const char *info );
 void jolt_gui_scr_menu_set_btn_selected(lv_obj_t *par, lv_obj_t *btn);
 
 /**
+ * @brief Remove an element from a menu.
+ * @param[in,out] par Jolt menu screen
+ * @param[in] btn List element to remove.
+ */
+void jolt_gui_scr_menu_remove(lv_obj_t *par, lv_obj_t *btn);
+
+/**
  * @brief Deletes elements from indicies start to end (inclusive) 
  * @param[in,out] par Jolt menu screen
  * @param[in] start Starting index to delete (inclusive).
  * @param[in] end Ending index to delete (inclusive). Set to 0 to delete all past start.
  */
-void jolt_gui_scr_menu_remove(lv_obj_t *par, uint16_t start, uint16_t end);
+void jolt_gui_scr_menu_remove_indices(lv_obj_t *par, uint16_t start, uint16_t end);
 
 /**
  * @brief Set the active object param and all of the buttons
@@ -99,5 +106,11 @@ void jolt_gui_scr_menu_set_param( lv_obj_t *par, void *param );
  * @return 0-Index of button. Returns -1 on error.
  */
 int32_t jolt_gui_scr_menu_get_btn_index( lv_obj_t *btn );
+
+/**
+ * @brief Get the number of elements in the menu
+ * @param[in] par Menu screen
+ */
+uint16_t jolt_gui_scr_menu_len(const lv_obj_t *par);
 
 #endif

--- a/jolt_os/jolt_gui/jolt_gui_menu.h
+++ b/jolt_os/jolt_gui/jolt_gui_menu.h
@@ -56,9 +56,17 @@ lv_obj_t *jolt_gui_scr_menu_get_scr( lv_obj_t *btn );
 /**
  * @brief Adds an item to a Jolt Menu Screen 
  * @param[in,out] btn Menu element to add a switch to
- * @return lv_sw object
+ * @return lv_sw object.
  */
 lv_obj_t *jolt_gui_scr_menu_add_sw( lv_obj_t *btn );
+
+/**
+ * @brief Displays a right-justified string for an element. This must be a short
+ * string, or else it might totally eclipse the menu element's label.
+ *
+ * @return created lv_label object.
+ */
+lv_obj_t *jolt_gui_scr_menu_add_info( lv_obj_t *btn, const char *info );
 
 /**
  * @brief Sets the current selection to btn 

--- a/jolt_os/jolt_gui/jolt_gui_yesno.c
+++ b/jolt_os/jolt_gui/jolt_gui_yesno.c
@@ -1,7 +1,18 @@
+
+#define LOG_LOCAL_LEVEL 4
+
 #include "esp_log.h"
 #include "jolt_gui/jolt_gui.h"
 
 static const char TAG[] = "jolt_gui_yesno";
+
+static void default_no_cb(lv_obj_t *btn, lv_event_t event) {
+    if( jolt_gui_event.short_clicked == event
+            || jolt_gui_event.cancel == event) {
+        ESP_LOGD(TAG, "Deleting yes/no screen via %s and event %d", __func__, event);
+        jolt_gui_scr_del(btn);
+    }
+}
 
 jolt_gui_obj_t * jolt_gui_scr_yesno_create(const char *title,
         jolt_gui_event_cb_t yes_cb, jolt_gui_event_cb_t no_cb ) {
@@ -9,6 +20,7 @@ jolt_gui_obj_t * jolt_gui_scr_yesno_create(const char *title,
     bool success = false;
     JOLT_GUI_CTX{
         scr = BREAK_IF_NULL(jolt_gui_scr_menu_create(title));
+        if( NULL == no_cb ) no_cb = default_no_cb;
         jolt_gui_scr_set_event_cb(scr, no_cb);
         BREAK_IF_NULL(jolt_gui_scr_menu_add(scr, NULL, gettext(JOLT_TEXT_NO), no_cb));
         BREAK_IF_NULL(jolt_gui_scr_menu_add(scr, NULL, gettext(JOLT_TEXT_YES), yes_cb));

--- a/jolt_os/jolt_gui/jolt_gui_yesno.h
+++ b/jolt_os/jolt_gui/jolt_gui_yesno.h
@@ -1,3 +1,10 @@
+/**
+ *
+ * @bugs 
+ *     * If you do not delete the yes/no screen in the callback, the `no` 
+ *       callback will execute with event `jolt_gui_event.short_clicked`.
+ */
+
 #ifndef JOLT_GUI_YESNO_H__
 #define JOLT_GUI_YESNO_H__
 
@@ -7,7 +14,8 @@
  * @brief Create a yes/no screen
  * @param[in] title title-bar string
  * @param[in] yes_cb Callback for "yes" selection
- * @param[in] no_cb Callback for "no" selection or pressing the back button
+ * @param[in] no_cb Callback for "no" selection or pressing the back button.
+ *            If `NULL`, defaults to deleting the screen.
  */
 jolt_gui_obj_t * jolt_gui_scr_yesno_create(const char *title,
         jolt_gui_event_cb_t yes_cb, jolt_gui_event_cb_t no_cb );

--- a/jolt_os/jolt_gui/menus/home.c
+++ b/jolt_os/jolt_gui/menus/home.c
@@ -108,7 +108,11 @@ void jolt_gui_menu_home_create() {
 
     jolt_gui_scr_menu_add(main_menu, NULL, gettext(JOLT_TEXT_SETTINGS), menu_settings_create);
 #if JOLT_GUI_TEST_MENU
-    jolt_gui_scr_menu_add(main_menu, NULL, "JSON", jolt_gui_test_json_create);
+    {
+        lv_obj_t * elem;
+        elem = jolt_gui_scr_menu_add(main_menu, NULL, "JSON", jolt_gui_test_json_create);
+        jolt_gui_scr_menu_add_info(elem, "123");
+    }
     jolt_gui_scr_menu_add(main_menu, NULL, "BigNum", jolt_gui_test_bignum_create);
     jolt_gui_scr_menu_add(main_menu, NULL, "QR", jolt_gui_test_qrcode_create);
     jolt_gui_scr_menu_add(main_menu, NULL, "Loading", jolt_gui_test_loading_create);

--- a/jolt_os/jolt_gui/menus/home.c
+++ b/jolt_os/jolt_gui/menus/home.c
@@ -123,6 +123,7 @@ void jolt_gui_menu_home_create() {
     jolt_gui_scr_menu_add(main_menu, NULL, "Alphabet and Scrolling Menu Option", jolt_gui_test_alphabet_create);
     jolt_gui_scr_menu_add(main_menu, NULL, "Https", jolt_gui_test_https_create);
 #endif
+    // TODO refresh on focus
     jolt_gui_scr_set_event_cb(main_menu, NULL); // don't allow the home screen to be deleted.
 }
 

--- a/jolt_os/jolt_gui/menus/settings/bluetooth.c
+++ b/jolt_os/jolt_gui/menus/settings/bluetooth.c
@@ -33,7 +33,7 @@ static void create_disable_list() {
 
 static void destroy_list() {
     /* Delete everything after the enable/disable element */
-     jolt_gui_scr_menu_remove(scr, 1, 0);
+     jolt_gui_scr_menu_remove_indices(scr, 1, 0);
 }
 
 static void sw_en_cb(jolt_gui_obj_t *btn, jolt_gui_event_t event) {

--- a/jolt_os/jolt_gui/menus/settings/storage.c
+++ b/jolt_os/jolt_gui/menus/settings/storage.c
@@ -1,27 +1,44 @@
 #include "jolt_gui/jolt_gui.h"
 #include "esp_log.h"
 #include "syscore/filesystem.h"
+#include "submenus.h"
+#include "jolt_helpers.h"
 
 
 static const char TAG[] = "gui_storage";
 
+static void menu_storage_callback(lv_obj_t *obj, jolt_gui_event_t event) {
+    if( jolt_gui_event.short_clicked == event ) {
+        /* Create Storage Details menu. */
+        menu_storage_details_create(obj, jolt_gui_event.short_clicked);
+
+    }
+    else if( jolt_gui_event.cancel == event ) {
+        jolt_gui_scr_del(obj);
+    }
+}
+
 void menu_storage_create(jolt_gui_obj_t *btn, jolt_gui_event_t event) {
     if( jolt_gui_event.short_clicked == event ) {
-        uint32_t tot, used;
+        uint32_t total, used;
         uint8_t percentage;
         char subtitle[50];
+        char used_buf[10];
+        char total_buf[10];
 
-        jolt_fs_info(&tot, &used);
-        percentage = (used*100)/tot;
+        jolt_fs_info(&total, &used);
+        percentage = (used*100)/total;
+        jolt_bytes_to_hstr(used_buf, sizeof(used_buf), used, 0);
+        jolt_bytes_to_hstr(total_buf, sizeof(total_buf), total, 0);
 
-        snprintf(subtitle, sizeof(subtitle), gettext(JOLT_TEXT_STORAGE_USAGE), used/1024, tot/1024);
+        snprintf(subtitle, sizeof(subtitle), gettext(JOLT_TEXT_STORAGE_USAGE), used_buf, total_buf);
         ESP_LOGD(TAG, "Storage subtitle: %s", subtitle);
 
         jolt_gui_obj_t *scr;
         scr = jolt_gui_scr_loadingbar_create( gettext(JOLT_TEXT_STORAGE) );
         if( NULL == scr ) goto exit;
         jolt_gui_scr_loadingbar_update(scr, NULL, subtitle, percentage);
-        jolt_gui_scr_set_event_cb(scr, jolt_gui_event_del);
+        jolt_gui_scr_set_event_cb(scr, menu_storage_callback);
     }
 
 exit:

--- a/jolt_os/jolt_gui/menus/settings/storage_details.c
+++ b/jolt_os/jolt_gui/menus/settings/storage_details.c
@@ -1,0 +1,161 @@
+/**
+ * @bugs
+ */
+
+//#define LOG_LOCAL_LEVEL 4
+
+#include "jolt_gui/jolt_gui.h"
+#include "esp_log.h"
+#include "syscore/filesystem.h"
+
+static const char TAG[] = "gui_storage_details";
+
+static lv_obj_t *btn_file = NULL;
+static lv_obj_t *scr_file_options = NULL;
+static lv_obj_t *scr_files = NULL;
+
+
+/**
+ * @brief Delete the file indicated by `btn_file`; 
+ */
+static void delete_file_cb(lv_obj_t *btn, lv_event_t event){
+    if( jolt_gui_event.short_clicked == event ) {
+        jolt_gui_scr_del(btn);
+
+        const char *fn = lv_list_get_btn_text(btn_file);
+        if( NULL == fn ) return;
+        ESP_LOGI(TAG, "Deleting file %s", fn);
+        char *path = jolt_fs_parse(fn, NULL);
+        if( NULL == path ) {
+            ESP_LOGE(TAG, "OOM parsing full path");
+            return;
+        }
+
+        if( jolt_fs_exists(path) ) {
+            remove(path);
+        }
+        else{
+            ESP_LOGE(TAG, "Cannot delete %s. Doesn't exist!", fn);
+        }
+        free(path);
+        jolt_gui_scr_del(scr_file_options);
+        {
+            uint16_t len;
+            len = jolt_gui_scr_menu_len(scr_files);
+            if(len > 1) {
+                jolt_gui_scr_menu_remove(scr_files, btn_file);
+            }
+            else{
+                jolt_gui_scr_del(scr_files);
+                scr_files = NULL;
+            }
+        }
+        btn_file = NULL;
+    }
+}
+
+/**
+ * @brief Create yes/no screen to delete a file.
+ */
+static void delete_file_confirm(lv_obj_t *btn, lv_event_t event) {
+    if( jolt_gui_event.short_clicked == event ) {
+        jolt_gui_scr_yesno_create(
+                gettext(JOLT_TEXT_STORAGE_DETAILS),
+                delete_file_cb, NULL);
+    }
+}
+
+/***
+ * @brief List actions user can perform on selected file.
+ */
+static lv_obj_t *menu_file_options_create() {
+    lv_obj_t *scr = NULL;
+    lv_obj_t *btn;
+    scr = jolt_gui_scr_menu_create(gettext(JOLT_TEXT_STORAGE_DETAILS));
+    if( NULL == scr ) goto exit;
+
+    btn = jolt_gui_scr_menu_add(scr, NULL, gettext(JOLT_TEXT_STORAGE_DELETE), delete_file_confirm);
+    if( NULL == btn ) goto exit;
+
+exit:
+    return scr;
+}
+
+/**
+ * Create menu to delete file, etc
+ */
+static void menu_storage_details_options_callback(lv_obj_t *btn, jolt_gui_event_t event) {
+    if( jolt_gui_event.short_clicked == event ) {
+        btn_file = btn;
+        scr_file_options = menu_file_options_create();
+    }
+}
+
+/**
+ * @brief add all the files in the filesystem and their sizes to the menu_scr.
+ *
+ * @return number of files added. Returns -1 on error
+ */
+static lv_obj_t *create_and_add_files_to_menu(){
+    DIR *dir = NULL;
+    struct dirent *ent;
+    struct stat sb;
+    lv_obj_t *scr = NULL;
+
+    if( !(dir = opendir(JOLT_FS_MOUNTPT)) ) {
+        ESP_LOGE(TAG, "Error opening directory\n");
+        goto exit;
+    }
+
+    /* Read directory entries */
+    while ((ent = readdir(dir)) != NULL) {
+        char tpath[JOLT_FS_MAX_ABS_PATH_BUF_LEN] = JOLT_FS_MOUNTPT;
+
+        assert( ent->d_type == DT_REG ); /* All objects should be files */
+
+        if( NULL == scr ) {
+            scr = jolt_gui_scr_menu_create(gettext(JOLT_TEXT_STORAGE_DETAILS));
+            if( NULL == scr ) goto exit;
+        }
+
+        lv_obj_t *btn = NULL, *info_label = NULL;
+        btn = jolt_gui_scr_menu_add(scr, NULL, ent->d_name, menu_storage_details_options_callback);
+        if( NULL == btn ) goto exit;
+
+        /* Parse full filepath */
+        if (tpath[strlen(tpath)-1] != '/') strlcat(tpath, "/", sizeof(tpath));
+        strlcat(tpath, ent->d_name, sizeof(tpath));
+        ESP_LOGD(TAG, "stat path \"%s\"", tpath);
+
+        if (stat(tpath, &sb)){
+            info_label = jolt_gui_scr_menu_add_info(btn, "???");
+            if( NULL == info_label ) goto exit;
+        }
+        else {
+            uint8_t precision = 0;
+            char size_buf[10];
+            if( sb.st_size >= MB ) precision = 1;
+            ESP_LOGD(TAG, "Precision: %d", precision);
+            jolt_bytes_to_hstr(size_buf, sizeof(size_buf), sb.st_size, precision);
+            info_label = jolt_gui_scr_menu_add_info(btn, size_buf);
+            if( NULL == info_label ) goto exit;
+        }
+    }
+
+exit:
+    if( NULL!=dir ) closedir(dir);
+    if( NULL == scr ) {
+        scr = jolt_gui_scr_text_create(gettext(JOLT_TEXT_STORAGE_DETAILS),
+                gettext(JOLT_TEXT_STORAGE_NO_FILES_FOUND));
+    }
+    return scr;
+}
+
+void menu_storage_details_create(jolt_gui_obj_t *btn, jolt_gui_event_t event) {
+    if( jolt_gui_event.short_clicked == event ) {
+        scr_files = create_and_add_files_to_menu();
+    }
+}
+
+
+

--- a/jolt_os/jolt_gui/menus/settings/storage_details.c
+++ b/jolt_os/jolt_gui/menus/settings/storage_details.c
@@ -37,7 +37,10 @@ static void delete_file_cb(lv_obj_t *btn, lv_event_t event){
         else{
             ESP_LOGE(TAG, "Cannot delete %s. Doesn't exist!", fn);
         }
-        free(path);
+        jolt_h_fn_home_refresh(path);
+
+        SAFE_FREE(path);
+
         jolt_gui_scr_del(scr_file_options);
         {
             uint16_t len;

--- a/jolt_os/jolt_gui/menus/settings/submenus.h
+++ b/jolt_os/jolt_gui/menus/settings/submenus.h
@@ -89,4 +89,9 @@ void menu_bluetooth_unbond_create(jolt_gui_obj_t *btn, jolt_gui_event_t event);
  */
 void menu_storage_create( jolt_gui_obj_t *btn, jolt_gui_event_t event );
 
+/**
+ * @brief List of installed applications and their sizes.
+ */
+void menu_storage_details_create( jolt_gui_obj_t *btn, jolt_gui_event_t event );
+
 #endif

--- a/jolt_os/jolt_gui/menus/settings/wifi.c
+++ b/jolt_os/jolt_gui/menus/settings/wifi.c
@@ -16,7 +16,7 @@ static void create_list() {
 }
 
 static void destroy_list() {
-     jolt_gui_scr_menu_remove(scr, 1, 0);
+     jolt_gui_scr_menu_remove_indices(scr, 1, 0);
 }
 
 static void sw_en_cb(jolt_gui_obj_t *btn, jolt_gui_event_t event) {

--- a/jolt_os/jolt_helpers.c
+++ b/jolt_os/jolt_helpers.c
@@ -3,6 +3,8 @@
  https://www.joltwallet.com/
  */
 
+//#define LOG_LOCAL_LEVEL 4
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -215,3 +217,15 @@ void jolt_resume_logging() {
     }
 }
 
+int jolt_bytes_to_hstr(char *buf, size_t size, size_t bytes, uint8_t precision) {
+	const char *suffix[] = {"B", "KB", "MB", "GB", "TB"};
+	char n_suffix = sizeof(suffix) / sizeof(suffix[0]);
+
+	uint8_t i;
+	double dbytes = bytes;
+
+    for(i=0; dbytes >= 1024 && (i < n_suffix); i++, dbytes /= 1024)
+        ;
+
+	return snprintf(buf, size, "%0.*lf %s", precision, dbytes, suffix[i]);
+}

--- a/jolt_os/jolt_helpers.h
+++ b/jolt_os/jolt_helpers.h
@@ -174,6 +174,17 @@ void jolt_suspend_logging();
  */
 void jolt_resume_logging();
 
+/**
+ * @brief Converts bytes into a human-friendly string.
+ * @param[out] buf Output buffer
+ * @param[in] size size of buf
+ * @param[in] Value of bytes to stringify.
+ * @param[in] Number of decimal places.
+ * @return The number of characters that would have been written if `size` had 
+ *         been sufficiently large, not counting the terminating null character.
+ */
+int jolt_bytes_to_hstr(char *buf, size_t size, size_t bytes, uint8_t precision);
+
 #include <driver/uart.h>
 #include "hal/radio/bluetooth.h"
 /* Log something to uart if BLE is the stdin */

--- a/jolt_os/jolt_helpers.h
+++ b/jolt_os/jolt_helpers.h
@@ -73,6 +73,17 @@
 #define RESTART_IF_NULL(x) ({ void *y = x; if(NULL == y) esp_restart(); y;})
 
 /**
+ * @brief Breaks if passed in value is NULL 
+ * @return passed in value
+ */
+#define BREAK_IF_NULL( obj ) ({\
+        void *x = obj; \
+        if( NULL == x ) break; \
+        x; \
+        })
+
+
+/**
  * @brief Fill a buffer with zeros. DO NOT USE FOR CONFIDENTIAL DATA.
  */
 #define memzero(buf, size) memset(buf, 0, size);

--- a/jolt_os/lang/english.c
+++ b/jolt_os/lang/english.c
@@ -25,6 +25,7 @@ const char *jolt_lang_english[JOLT_TEXT_LAST_STR] = {
     "Brightness",
     "Factory Reset",
     "Storage",
+    "Storage Details",
 
     /* Language Names */
     "Language",
@@ -51,7 +52,9 @@ const char *jolt_lang_english[JOLT_TEXT_LAST_STR] = {
     "Update WiFi to:\nSSID: %s\nPassword: %s",
 
     /* Storage Options */
-    "%dKB Used / %dKB Total",
+    "%s Used / %s Total",
+    "No files found.",
+    "Delete",
 
     /* Mnemonic Restore */
     "Mnemonic Restore",

--- a/jolt_os/lang/lang.h
+++ b/jolt_os/lang/lang.h
@@ -53,6 +53,7 @@ typedef enum jolt_text_id_t {
     JOLT_TEXT_BRIGHTNESS,
     JOLT_TEXT_FACTORY_RESET,
     JOLT_TEXT_STORAGE,
+    JOLT_TEXT_STORAGE_DETAILS,
 
     /* Language Names */
     JOLT_TEXT_LANGUAGE,
@@ -80,6 +81,8 @@ typedef enum jolt_text_id_t {
 
     /* Storage Options */
     JOLT_TEXT_STORAGE_USAGE,
+    JOLT_TEXT_STORAGE_NO_FILES_FOUND,
+    JOLT_TEXT_STORAGE_DELETE,
 
     /* Mnemonic Restore */
     JOLT_TEXT_MNEMONIC_RESTORE,

--- a/jolt_os/lang/spanish.c
+++ b/jolt_os/lang/spanish.c
@@ -25,6 +25,7 @@ const char *jolt_lang_spanish[JOLT_TEXT_LAST_STR] = {
     "Brillo",
     "Restablecimiento de fábrica",
     "Almacenamiento",
+    "Detalles de Almacenamiento",
 
     /* Language Names */
     "Idioma",
@@ -51,7 +52,9 @@ const char *jolt_lang_spanish[JOLT_TEXT_LAST_STR] = {
     "Actualizar WiFi a:\nSSID: %s\nContraseña: %s",
 
     /* Storage Options */
-    "%dKB Usado / %dKB Total",
+    "%s Usado / %s Total",
+    "No se encontraron archivos.",
+    "Borrar",
 
     /* Mnemonic Restore */
     "restauración mnemónica",

--- a/jolt_os/syscore/cli.c
+++ b/jolt_os/syscore/cli.c
@@ -438,6 +438,16 @@ static void jolt_cli_cmds_register() {
 
 #if JOLT_GUI_TEST_MENU
     cmd = (esp_console_cmd_t) {
+        .command = "touch",
+        .help = "Create empty file(s).",
+        .hint = NULL,
+        .func = &jolt_cmd_touch,
+    };
+    ESP_ERROR_CHECK( esp_console_cmd_register(&cmd) );
+#endif
+
+#if JOLT_GUI_TEST_MENU
+    cmd = (esp_console_cmd_t) {
         .command = "unlock",
         .help = "Prompts user to enter PIN and unlock device.",
         .hint = NULL,

--- a/jolt_os/syscore/cli_uart.c
+++ b/jolt_os/syscore/cli_uart.c
@@ -120,7 +120,11 @@ static void jolt_cli_uart_listener_task( void *param) {
 
         if( 0 == strcmp(line, "upload_firmware")
                 || 0 == strcmp(line, "upload")
-                || 0 == strncmp(line, "upload ", 7)){
+                || 0 == strncmp(line, "upload ", 7)
+#if JOLT_GUI_TEST_MENU
+                || 0 == strcmp(line, "display")
+#endif
+                ){
             suspend = true;
         }
         else if( 0 == strcmp(line, "ping") ) {

--- a/jolt_os/syscore/cmd/jolt_cmd_display.c
+++ b/jolt_os/syscore/cmd/jolt_cmd_display.c
@@ -3,5 +3,6 @@
 
 int jolt_cmd_display(int argc, char** argv) {
     print_display_buf();
+    jolt_cli_resume();
     return 0;
 }

--- a/jolt_os/syscore/cmd/jolt_cmd_mv.c
+++ b/jolt_os/syscore/cmd/jolt_cmd_mv.c
@@ -18,6 +18,8 @@ int jolt_cmd_mv(int argc, char** argv) {
 
     if( ESP_OK != jolt_fs_mv(src_fn, dst_fn) ) EXIT_PRINT(-4, "Unsuccessful move");
 
+    jolt_h_fn_home_refresh(dst_fn);
+
     EXIT(0); /* Success */
 
 exit:

--- a/jolt_os/syscore/cmd/jolt_cmd_touch.c
+++ b/jolt_os/syscore/cmd/jolt_cmd_touch.c
@@ -1,0 +1,34 @@
+#include "stdio.h"
+#include "esp_vfs_dev.h"
+#include "syscore/cli_helpers.h"
+#include "syscore/filesystem.h"
+#include "jolt_helpers.h"
+
+
+int jolt_cmd_touch(int argc, char** argv) {
+    int return_code;
+    uint8_t files_created = 0;
+
+    /* Input Argument Check */
+    if( argc < 2 ) EXIT_PRINT(-1, "Specify at least 1 filename");
+
+    for(uint8_t i=1; i<argc; i++){
+        FILE *f = NULL;
+        char *fn = BREAK_IF_NULL(jolt_fs_parse(argv[i], NULL));
+        f = fopen(fn, "wb");
+        if( NULL != f ) jolt_h_fn_home_refresh(fn);
+        SAFE_FREE(fn);
+        if( NULL == f ) break;
+        files_created++;
+        SAFE_CLOSE(f);
+    }
+
+    if( files_created != argc - 1 ) EXIT(-1);
+
+    EXIT(0); /* Success */
+
+exit:
+    return return_code;
+}
+
+

--- a/jolt_os/syscore/cmd/jolt_cmds.h
+++ b/jolt_os/syscore/cmd/jolt_cmds.h
@@ -155,6 +155,13 @@ int jolt_cmd_task_status(int argc, char** argv);
  */
 int jolt_cmd_top(int argc, char** argv);
 
+#if JOLT_GUI_TEST_MENU
+/**
+ * @brief Create empty file(s)
+ */
+int jolt_cmd_touch(int argc, char **argv);
+#endif
+
 /**
  * @brief Enters file UART ymodem upload mode
  *

--- a/jolt_os/syscore/filesystem.h
+++ b/jolt_os/syscore/filesystem.h
@@ -18,6 +18,11 @@
 #include "sdkconfig.h"
 #include "esp_err.h"
 
+#define KB (1<<10)
+#define MB (1<<20)
+#define GB (1<<30)
+#define TB (1<<40)
+
 /**
  * @brief Mounting point for filesystem
  * 


### PR DESCRIPTION
* Settings>Storage>Details menu
* `jolt_gui_scr_menu_add_info` command to add right-justified meta text to a menu element.
* `touch` cli cmd while running `test-menu`
* Improve home-screen refresh logic
* Improve some `JOLT_GUI_CTX` error handling
* Explicitly pause the UART CLI while exporting a screenshot